### PR TITLE
Add database setup script

### DIFF
--- a/Backend/init_db.py
+++ b/Backend/init_db.py
@@ -1,0 +1,24 @@
+import os
+import sqlite3
+
+DB_PATH = os.path.join(os.path.dirname(__file__), "users.db")
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email TEXT UNIQUE NOT NULL,
+    password TEXT NOT NULL,
+    role TEXT NOT NULL
+)
+"""
+
+def init_db(db_path=DB_PATH):
+    conn = sqlite3.connect(db_path)
+    c = conn.cursor()
+    c.execute(SCHEMA)
+    conn.commit()
+    conn.close()
+    print(f"Database initialized at {db_path}.")
+
+if __name__ == "__main__":
+    init_db()

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # Improving the frontend
+
+## Database setup
+
+The backend uses a simple SQLite database stored as `Backend/users.db`.
+To create the database and the required `users` table, run:
+
+```bash
+python Backend/init_db.py
+```
+
+This script creates the database file if it does not exist.


### PR DESCRIPTION
## Summary
- add a small SQLite initialization script
- document how to run it in the README

## Testing
- `python -m py_compile Backend/init_db.py`
- `python -m py_compile Backend/app.py`
- `python Backend/init_db.py`


------
https://chatgpt.com/codex/tasks/task_e_684aa91c52f08328b44aedc7be2b33f5