### PR TITLE
Enable AES encryption for credentials

### DIFF
--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -16,3 +16,4 @@ pytz==2025.2
 six==1.17.0
 tzdata==2025.2
 Werkzeug==3.1.3
+cryptography==42.0.5

--- a/Backend/view-users.py
+++ b/Backend/view-users.py
@@ -1,4 +1,17 @@
 import sqlite3
+from cryptography.fernet import Fernet
+import os
+
+FERNET_KEY = os.getenv("FERNET_KEY")
+if not FERNET_KEY:
+    FERNET_KEY = Fernet.generate_key().decode()
+cipher = Fernet(FERNET_KEY.encode())
+
+def decrypt_pw(token: str) -> str:
+    try:
+        return cipher.decrypt(token.encode()).decode()
+    except Exception:
+        return token
 
 # Connect to the SQLite database
 conn = sqlite3.connect("users.db")
@@ -11,6 +24,9 @@ users = c.fetchall()
 # Print users
 print("All registered users:")
 for user in users:
-    print(user)
+    user_list = list(user)
+    if len(user_list) > 2:
+        user_list[2] = decrypt_pw(user_list[2])
+    print(tuple(user_list))
 
 conn.close()


### PR DESCRIPTION
## Summary
- add `cryptography` to requirements
- store passwords encrypted with AES-based Fernet
- allow login with either encrypted or previously hashed passwords
- decrypt credentials when running `view-users.py`
