### PR TITLE
Fix registration data posting

### DIFF
--- a/Backend/static/Js/registration.js
+++ b/Backend/static/Js/registration.js
@@ -1,5 +1,4 @@
 document.getElementById("registrationForm").addEventListener("submit", function(e) {
- 
 
   const email = document.getElementById("email").value.trim();
   const password = document.getElementById("password").value.trim();
@@ -8,6 +7,7 @@ document.getElementById("registrationForm").addEventListener("submit", function(
 
   // Basic validation for email and password
   if (!email || !password) {
+    e.preventDefault();
     alert("Please fill in all fields.");
     return;
   }
@@ -15,27 +15,26 @@ document.getElementById("registrationForm").addEventListener("submit", function(
   // Regex for basic email validation
   const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$/;
   if (!emailRegex.test(email)) {
+    e.preventDefault();
     alert("Please enter a valid email address.");
     return;
   }
 
   // Password Strength validation (at least 12 characters)
   if (password.length < 12) {
+    e.preventDefault();
     alert("Password must be at least 12 characters long.");
     return;
   }
 
   if (!stakeholder && !manager) {
+    e.preventDefault();
     alert("Please select a role to register.");
     return;
   }
 
-  // Displaying the collected data
+  // Debugging output
   console.log("Email:", email);
   console.log("Password:", password);
   console.log("Roles:", { stakeholder, manager });
-
-  // On successful registration, reset the form and show a success message
-  alert("Registration successful!");
-  document.getElementById("registrationForm").reset();
 });


### PR DESCRIPTION
## Summary
- prevent registration form from clearing values before submission
- keep validation but remove client-side success alert

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab8eef384832884a990b9571afb03