### PR TITLE
Fix missing forgot password route

### DIFF
--- a/Backend/app.py
+++ b/Backend/app.py
@@ -96,6 +96,21 @@ def stakeholder_dashboard():
     return render_template('stakeholder-landing-dashboard.html')
 
 
+@app.route('/forgot-password', methods=['GET', 'POST'])
+def forgot_password():
+    """Simple password reset placeholder."""
+    if request.method == 'POST':
+        email = request.form.get('email')
+        if not email:
+            flash('Please enter your email address.', 'error')
+            return redirect(url_for('forgot_password'))
+
+        flash('If an account exists for %s, a reset link has been sent.' % email, 'info')
+        return redirect(url_for('login'))
+
+    return render_template('forgot_password.html')
+
+
 @app.route('/coming_soon/<page>')
 def coming_soon(page):
     """Display placeholder pages for features not yet implemented."""

--- a/Backend/templates/forgot_password.html
+++ b/Backend/templates/forgot_password.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% block title %}Forgot Password{% endblock %}
+{% block extra_head %}
+  <link rel="stylesheet" href="{{ url_for('static', filename='Css/style.css') }}" />
+  <link rel="stylesheet" href="{{ url_for('static', filename='Css/login.css') }}" />
+{% endblock %}
+{% block content %}
+<main class="login-main">
+  <div class="login-card">
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      <ul class="flashes">
+        {% for category, msg in messages %}
+        <li class="flash {{ category }}">{{ msg }}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+    {% endwith %}
+    <h2 class="login-title">Forgot Password</h2>
+    <form action="{{ url_for('forgot_password') }}" method="post" class="login-form">
+      <div class="form-group">
+        <label for="email">Email</label>
+        <input type="email" id="email" name="email" placeholder="abc@analyticsinstitute.edu.au" required>
+      </div>
+      <button type="submit" class="btn-primary">Send reset link</button>
+    </form>
+  </div>
+</main>
+{% endblock %}
+{% block extra_js %}{% endblock %}


### PR DESCRIPTION
## Summary
- add forgot password page and route
- reference new page from login

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ac3e3e8c08328b228cbe30738bbd8