### PR TITLE
Add reports page and link

### DIFF
--- a/Backend/app.py
+++ b/Backend/app.py
@@ -117,6 +117,12 @@ def help_page():
     return render_template('help.html')
 
 
+@app.route('/reports')
+def reports():
+    """Display available Power BI reports and contact info."""
+    return render_template('reports.html')
+
+
 @app.route('/coming_soon/<page>')
 def coming_soon(page):
     """Display placeholder pages for features not yet implemented."""

--- a/Backend/templates/partials/navbar.html
+++ b/Backend/templates/partials/navbar.html
@@ -10,7 +10,7 @@
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
         <li class="nav-item"><a class="nav-link" href="{{ url_for('home') }}">Home</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('dashboard') }}">Dashboard</a></li>
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('coming_soon', page='reports') }}">Reports</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('reports') }}">Reports</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('help_page') }}">Help</a></li>
       </ul>
       <div class="d-flex">

--- a/Backend/templates/reports.html
+++ b/Backend/templates/reports.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block title %}Reports{% endblock %}
+{% block content %}
+<div class="container py-5">
+  <h1 class="mb-4">Reports</h1>
+  <p class="lead">Interactive Power BI reports will be available here soon. You will be able to filter data, download results and explore trends once the feature is released.</p>
+  <p class="mb-4">If you require report data in the meantime, please contact our team:</p>
+  <ul>
+    <li>Email: <a href="mailto:info@analyticsinstitute.edu.au">info@analyticsinstitute.edu.au</a></li>
+    <li>Phone: (+61) 426 799 276</li>
+    <li>Address: Pearl Level 10, 607 Bourke St, Melbourne VIC 3000</li>
+  </ul>
+  <a class="btn btn-primary mt-3" href="{{ url_for('home') }}">Return Home</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create `/reports` route and stub template
- link the new page from the navbar

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ad01f7f588328bb472eeb36a6ecac