### PR TITLE
Improve global styling with Inter font

### DIFF
--- a/Backend/static/Css/landing.css
+++ b/Backend/static/Css/landing.css
@@ -8,7 +8,7 @@
 }
 
 body {
-  font-family: 'Poppins', sans-serif;
+  font-family: 'Inter', sans-serif;
   color: #333;
   background-color: #fff;
   margin: 0;

--- a/Backend/static/Css/login.css
+++ b/Backend/static/Css/login.css
@@ -6,7 +6,7 @@
 }
 html, body {
   height: 100%;
-  font-family: Arial, sans-serif;
+  font-family: 'Inter', sans-serif;
 }
 body {
   display: flex;

--- a/Backend/static/Css/main.css
+++ b/Backend/static/Css/main.css
@@ -1,0 +1,10 @@
+body {
+  font-family: 'Inter', sans-serif;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  color: #333;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-weight: 600;
+}

--- a/Backend/static/Css/registration.css
+++ b/Backend/static/Css/registration.css
@@ -7,7 +7,7 @@
 
 body, html {
   height: 100%;
-  font-family: Arial, sans-serif;
+  font-family: 'Inter', sans-serif;
   display: flex;
   flex-direction: column;
   background-color: #f9f9f9;

--- a/Backend/static/Css/style.css
+++ b/Backend/static/Css/style.css
@@ -8,7 +8,7 @@
 }
 
 body {
-  font-family: Arial, sans-serif;
+  font-family: 'Inter', sans-serif;
   background: #fff;
   color: #333;
 }

--- a/Backend/templates/base.html
+++ b/Backend/templates/base.html
@@ -4,8 +4,12 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{% block title %}Analytics Institute{% endblock %}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="{{ url_for('static', filename='Css/main.css') }}" />
   <link rel="stylesheet" href="{{ url_for('static', filename='Css/landing.css') }}" />
   {% block extra_head %}{% endblock %}
 </head>


### PR DESCRIPTION
## Summary
- add Inter web font via Google Fonts
- apply Inter font sitewide with new `main.css`
- update page-specific styles to use the new font

## Testing
- `python3 -m py_compile Backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684ad73394148328b1fe6859872e9896