### PR TITLE
Fix logout button showing when not logged in

### DIFF
--- a/Backend/templates/managerial-landing-dashboard.html
+++ b/Backend/templates/managerial-landing-dashboard.html
@@ -28,7 +28,7 @@
         <a href="{{ url_for('main.help_page') }}">Help</a>
       </div>
       <div class="user-profile dropdown">
-        <button class="dropdown-toggle">{{ session['email'].split('@')[0] | title }} ▾</button>
+        <button class="dropdown-toggle">{{ current_user.email.split('@')[0] | title }} ▾</button>
         <ul class="profile-dropdown">
           <li><a id="logout-link" href="{{ url_for('auth.logout') }}">Logout</a></li>
         </ul>

--- a/Backend/templates/partials/navbar.html
+++ b/Backend/templates/partials/navbar.html
@@ -9,18 +9,16 @@
     <div class="collapse navbar-collapse" id="navbarNav">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
         <li class="nav-item"><a class="nav-link" href="{{ url_for('main.home') }}">Home</a></li>
-        {% if session.get('role', '').lower() == 'manager' %}
+        {% if current_user.is_authenticated and current_user.role.lower() == 'manager' %}
         <li class="nav-item"><a class="nav-link" href="{{ url_for('dashboard.dashboard') }}">Dashboard</a></li>
-        {% elif session.get('role', '').lower() == 'stakeholder' %}
+        {% elif current_user.is_authenticated and current_user.role.lower() == 'stakeholder' %}
         <li class="nav-item"><a class="nav-link" href="{{ url_for('dashboard.stakeholder_dashboard') }}">Dashboard</a></li>
-        {% else %}
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('dashboard.dashboard') }}">Dashboard</a></li>
         {% endif %}
         <li class="nav-item"><a class="nav-link" href="{{ url_for('main.reports') }}">Reports</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('main.help_page') }}">Help</a></li>
       </ul>
       <div class="d-flex">
-        {% if session.get('email') %}
+        {% if current_user.is_authenticated %}
           <a href="{{ url_for('auth.logout') }}" class="btn btn-outline-secondary">Logout</a>
         {% else %}
           <a href="{{ url_for('auth.login') }}" class="btn btn-outline-secondary me-2">Sign in</a>


### PR DESCRIPTION
## Summary
- only show dashboard links when logged in
- hide Logout when user isn't authenticated
- use current_user email on managerial dashboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ae0f8e9d8832880ef28d403a6840e