### PR TITLE
Fix database initialization

### DIFF
--- a/Backend/init_db.py
+++ b/Backend/init_db.py
@@ -1,8 +1,16 @@
+"""Database initialization utility for the Flask application."""
+
 from app import create_app
 from models import db
+
+
+def init_database(app) -> None:
+    """Recreate all tables for a clean database state."""
+    db.drop_all()
+    db.create_all()
+    print(f"Database initialized at {app.config['SQLALCHEMY_DATABASE_URI']}")
 
 if __name__ == "__main__":
     app = create_app()
     with app.app_context():
-        db.create_all()
-        print(f"Database initialized at {app.config['SQLALCHEMY_DATABASE_URI']}")
+        init_database(app)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A Flask web application for hosting Power BI dashboards for the Analytics Instit
 # Install dependencies
  pip install -r requirements.txt
 
-# Initialize the database (uses Flask-Migrate)
+# Initialize the database (drops existing tables)
  python init_db.py
 ```
 


### PR DESCRIPTION
## Summary
- recreate existing tables when running `init_db.py`
- note in README that the init script drops existing tables
