### PR TITLE
Add predefined admin user with secure panel access

### DIFF
--- a/Backend/templates/partials/navbar.html
+++ b/Backend/templates/partials/navbar.html
@@ -20,7 +20,7 @@
       <div class="d-flex">
         {% if current_user.is_authenticated %}
           <a href="{{ url_for('auth.profile') }}" class="btn btn-outline-light me-2">Profile</a>
-          {% if current_user.role.name.lower() == 'manager' %}
+          {% if current_user.role.name.lower() == 'admin' %}
             <a href="{{ url_for('admin.index') }}" class="btn btn-outline-light me-2">Admin</a>
           {% endif %}
           <a href="{{ url_for('auth.logout') }}" class="btn btn-outline-light">Logout</a>

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ python app.py
 
 The application starts on **http://localhost:5001**. Visit this URL in your browser to see the landing page. Use the **Register** link to create an account. Managers are redirected to the managerial dashboard; stakeholders go to their own dashboard.
 
+### Default Admin Account
+
+An administrator account is created automatically when the application starts if it doesn't already exist:
+
+- **Email:** `admin@gmai.com`
+- **Password:** `admin123456789`
+
+Only this user has access to the Flask-Admin interface.
+
 ### Viewing Registered Users
 
 A helper script prints all registered users from the SQLite database:


### PR DESCRIPTION
## Summary
- restrict Flask-Admin views to authenticated users with the `Admin` role
- auto-create `Admin` role and default admin user `admin@gmai.com`
- update navbar to only show Admin link to admin role users
- document default admin credentials

