### PR TITLE
Restrict admin role registration

### DIFF
--- a/Backend/auth.py
+++ b/Backend/auth.py
@@ -21,8 +21,15 @@ auth_bp = Blueprint('auth', __name__)
 @auth_bp.route('/register', methods=['GET', 'POST'])
 def register():
     form = RegistrationForm()
-    form.role.choices = [(r.id, r.name) for r in Role.query.all()]
+    # Exclude the Admin role from the registration choices
+    form.role.choices = [
+        (r.id, r.name) for r in Role.query.filter(Role.name != "Admin")
+    ]
     if form.validate_on_submit():
+        selected_role = db.session.get(Role, form.role.data)
+        if selected_role and selected_role.name.lower() == "admin":
+            flash("Admin registration is not allowed", "error")
+            return redirect(url_for("auth.register"))
         if User.query.filter_by(email=form.email.data).first():
             flash('Email already exists', 'error')
             return redirect(url_for('auth.register'))

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ An administrator account is created automatically when the application starts if
 
 Only that user has access to the Flask-Admin interface.
 
+New users can register only as Manager or Stakeholder. The Admin role is
+reserved for the predefined account and is hidden from the registration form.
+
 ### Viewing Registered Users
 
 A helper script prints all registered users from the SQLite database:


### PR DESCRIPTION
## Summary
- hide the Admin role in registration and forbid users from choosing it
- document that only the predefined Admin account exists
