### PR TITLE
Fix duplicate block in admin template

### DIFF
--- a/Backend/templates/admin/master.html
+++ b/Backend/templates/admin/master.html
@@ -1,8 +1,10 @@
 {% extends 'admin/base.html' %}
+
 {% block head_css %}
     {{ super() }}
     <link rel="stylesheet" href="{{ url_for('static', filename='Css/admin.css') }}">
 {% endblock %}
+
 {% block menu_links %}
     <ul class="nav navbar-nav navbar-right">
         {{ layout.menu_links() }}
@@ -10,12 +12,4 @@
             <a class="btn btn-outline-light admin-logout" href="{{ url_for('auth.logout') }}">Logout</a>
         </li>
     </ul>
-{% endblock %}
-
-{% extends 'admin/base.html' %}
-{% block menu_links %}
-    {{ super() }}
-    <li class="nav-item">
-        <a class="nav-link" href="{{ url_for('auth.logout') }}">Logout</a>
-    </li>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove repeated `menu_links` block in `Backend/templates/admin/master.html`
