### PR TITLE
Implement CSV import workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ frontend/             # Client-side assets
 - Added password reset via email
 - Users can edit profile and change password
 - Included Flask-Admin interface for managing users and roles
+- Added CSV data import workflow with manager approval before stakeholder visibility
 
 #### Security & Role Management
 - Role-based access now dynamically managed via database (not hardcoded)
@@ -113,6 +114,12 @@ frontend/             # Client-side assets
 #### UI/UX and Documentation
 - Refined landing page visuals and dashboard icons
 - Updated README with full deployment instructions
+
+### Data Import Workflow
+1. **Admin uploads CSV** via the **Import Data** link (also accessible from the Manager dashboard sidebar).
+2. Uploaded rows are stored in the database as `ImportedData` records.
+3. **Managers** can review and approve these rows from their dashboard.
+4. Approved rows become visible on the Stakeholder dashboard as summary metrics.
 
 ---
 

--- a/frontend/static/Js/managerial-landing-dashboard.js
+++ b/frontend/static/Js/managerial-landing-dashboard.js
@@ -86,7 +86,7 @@ document.addEventListener("DOMContentLoaded", function () {
       "+" + topPct + "% chose " + topReason;
   }
 
-  fetch("/api/data")
+  fetch("/api/imported")
     .then(res => res.json())
     .then(data => {
       allData = data;

--- a/frontend/templates/import_data.html
+++ b/frontend/templates/import_data.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block title %}Import Data{% endblock %}
+{% block content %}
+<div class="container py-5">
+  <h1 class="mb-4">Import CSV Data</h1>
+  <form method="post" enctype="multipart/form-data">
+    {{ form.hidden_tag() }}
+    <div class="mb-3">
+      {{ form.file.label(class="form-label") }}
+      {{ form.file(class="form-control") }}
+    </div>
+    {{ form.submit(class="btn btn-primary") }}
+  </form>
+</div>
+{% endblock %}

--- a/frontend/templates/managerial-landing-dashboard.html
+++ b/frontend/templates/managerial-landing-dashboard.html
@@ -14,6 +14,9 @@
       <li class="active"><a href="{{ url_for('dashboard.dashboard') }}">Dashboard</a></li>
       <li><a href="{{ url_for('main.coming_soon', page='create-dashboard') }}">Create Dashboard</a></li>
       <li><a href="{{ url_for('main.coming_soon', page='download-data') }}">Download Data</a></li>
+      {% if current_user.role.name.lower() == 'admin' %}
+      <li><a href="{{ url_for('dashboard.import_data') }}">Import Data</a></li>
+      {% endif %}
       <li><a href="{{ url_for('main.coming_soon', page='settings') }}">Settings</a></li>
     </ul>
   </nav>
@@ -77,6 +80,27 @@
       <div class="mt-4">
         <iframe title="Manager Report" width="100%" height="600" src="https://app.powerbi.com/view?r=MANAGER_REPORT_ID" frameborder="0" allowfullscreen="true"></iframe>
       </div>
+
+      <div class="mt-5">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+          <h2 class="mb-0">Recently Imported Data</h2>
+          {% if current_user.role.name.lower() == 'admin' %}
+          <a class="btn btn-success" href="{{ url_for('dashboard.import_data') }}">Import Data</a>
+          {% endif %}
+        </div>
+        <table class="table" id="importedTable">
+        <table class="table" id="importedTable">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Data</th>
+              <th>Status</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
     </section>
     <footer class="footer">
       <p>Copyright © 2025 Analytics Institute of Australia</p>
@@ -87,4 +111,19 @@
 {% block extra_js %}
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="{{ url_for('static', filename='Js/managerial-landing-dashboard.js') }}" defer></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      fetch('/api/imported')
+        .then(res => res.json())
+        .then(rows => {
+          const tbody = document.querySelector('#importedTable tbody');
+          rows.forEach(r => {
+            const tr = document.createElement('tr');
+            const approveBtn = r.approved ? '' : `<form method="post" action="/approve/${r.id}"><button class="btn btn-sm btn-primary">Approve</button></form>`;
+            tr.innerHTML = `<td>${r.id}</td><td><pre>${JSON.stringify(r.data)}</pre></td><td>${r.approved ? 'Published' : 'Pending'}</td><td>${approveBtn}</td>`;
+            tbody.appendChild(tr);
+          });
+        });
+    });
+  </script>
 {% endblock %}

--- a/frontend/templates/partials/navbar.html
+++ b/frontend/templates/partials/navbar.html
@@ -14,6 +14,9 @@
         {% elif current_user.is_authenticated and current_user.role.name.lower() == 'stakeholder' %}
         <li class="nav-item"><a class="nav-link" href="{{ url_for('dashboard.stakeholder_dashboard') }}">Dashboard</a></li>
         {% endif %}
+        {% if current_user.is_authenticated and current_user.role.name.lower() == 'admin' %}
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('dashboard.import_data') }}">Import Data</a></li>
+        {% endif %}
         <li class="nav-item"><a class="nav-link" href="{{ url_for('main.reports') }}">Reports</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('main.help_page') }}">Help</a></li>
       </ul>

--- a/frontend/templates/stakeholder-landing-dashboard.html
+++ b/frontend/templates/stakeholder-landing-dashboard.html
@@ -9,9 +9,33 @@
     <div class="mb-4 text-center">
       <iframe title="Stakeholder Report" width="100%" height="600" src="https://app.powerbi.com/view?r=STAKEHOLDER_REPORT_ID" frameborder="0" allowfullscreen="true"></iframe>
     </div>
+    <div class="my-4">
+      <h2>Published Metrics</h2>
+      <table class="table" id="publishedTable">
+        <thead><tr><th>Record</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
     <div class="text-center">
       <a class="btn btn-primary me-2" href="{{ url_for('dashboard.export_data', fmt='pdf') }}">Export PDF</a>
       <a class="btn btn-secondary" href="{{ url_for('dashboard.export_data', fmt='excel') }}">Export Excel</a>
     </div>
   </div>
+{% endblock %}
+
+{% block extra_js %}
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      fetch('/api/published')
+        .then(res => res.json())
+        .then(rows => {
+          const tbody = document.querySelector('#publishedTable tbody');
+          rows.forEach(r => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `<td><pre>${JSON.stringify(r)}</pre></td>`;
+            tbody.appendChild(tr);
+          });
+        });
+    });
+  </script>
 {% endblock %}

--- a/server/forms/__init__.py
+++ b/server/forms/__init__.py
@@ -1,4 +1,5 @@
 from flask_wtf import FlaskForm
+from flask_wtf.file import FileField, FileAllowed, FileRequired
 from wtforms import StringField, PasswordField, SelectField, SubmitField
 from wtforms.validators import DataRequired, Email, Length, EqualTo
 
@@ -34,3 +35,8 @@ class ChangePasswordForm(FlaskForm):
     new_password = PasswordField('New Password', validators=[DataRequired(), Length(min=6), EqualTo('confirm', message='Passwords must match')])
     confirm = PasswordField('Confirm Password', validators=[DataRequired()])
     submit = SubmitField('Change Password')
+
+
+class CSVUploadForm(FlaskForm):
+    file = FileField('CSV File', validators=[FileRequired(), FileAllowed(['csv'], 'CSV only!')])
+    submit = SubmitField('Upload')

--- a/server/models/__init__.py
+++ b/server/models/__init__.py
@@ -39,3 +39,18 @@ class ActivityLog(db.Model):
 
     def __repr__(self) -> str:
         return f"<Activity {self.activity_type} user={self.user_id}>"
+
+
+class ImportedData(db.Model):
+    """Store rows imported from CSV files."""
+    __tablename__ = 'imported_data'
+    id = db.Column(db.Integer, primary_key=True)
+    data = db.Column(db.JSON, nullable=False)
+    approved = db.Column(db.Boolean, default=False)
+    uploaded_by_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=True)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+
+    uploaded_by = db.relationship('User', backref='imports')
+
+    def __repr__(self) -> str:
+        return f"<ImportedData {self.id} approved={self.approved}>"


### PR DESCRIPTION
## Summary
- add `ImportedData` model for storing uploaded records
- support CSV uploads via `/admin/import-data`
- show import table on manager dashboard with approve action
- display approved data on stakeholder dashboard
- add missing Import Data buttons and docs

## Testing
- `python -m py_compile server/blueprints/dashboard.py server/forms/__init__.py server/models/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_684e5752c2d08328aef1c66d3933f2c7