### PR TITLE
Fix manager dashboard layout

### DIFF
--- a/frontend/static/Css/style.css
+++ b/frontend/static/Css/style.css
@@ -257,3 +257,29 @@ body {
     height: auto;
   }
 }
+
+/* Additional responsive fixes for manager dashboard */
+.chart-card canvas {
+  width: 100% !important;
+  height: 260px !important;
+}
+
+.dashboard-body iframe {
+  width: 100%;
+  border: none;
+}
+
+@media (max-width: 992px) {
+  .app-container {
+    flex-direction: column;
+  }
+  .sidebar {
+    width: 100%;
+    flex-direction: row;
+    border-right: none;
+    border-bottom: 1px solid #ddd;
+  }
+  .main-content {
+    width: 100%;
+  }
+}

--- a/frontend/templates/managerial-landing-dashboard.html
+++ b/frontend/templates/managerial-landing-dashboard.html
@@ -4,7 +4,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='Css/style.css') }}" />
 {% endblock %}
 {% block content %}
-<div class="app-container">
+<div class="container-fluid app-container">
   <nav class="sidebar">
     <div class="logo">
       <img src="{{ url_for('static', filename='Assets/logo.png') }}" alt="Analytics Institute Logo" />


### PR DESCRIPTION
## Summary
- tweak layout in manager dashboard by using `container-fluid`
- add responsive styles for charts, iframe and sidebar
