### PR TITLE
Enable manager dashboard pages and clean layout

### DIFF
--- a/frontend/static/Js/manager-report.js
+++ b/frontend/static/Js/manager-report.js
@@ -1,0 +1,69 @@
+// Render report specific charts
+function renderReport(data) {
+  let ctx = document.getElementById('reportChart');
+  if (!ctx) return;
+
+  let chartType = 'bar';
+  let chartData = {};
+  let options = { responsive: true };
+
+  if (reportName === 'current-student') {
+    chartType = 'line';
+    const dates = [...new Set(data.map(r => r.StartDate).filter(Boolean))]
+      .sort((a, b) => new Date(a) - new Date(b));
+    const studentCounts = dates.map(d => data.filter(r => r.StartDate === d && r.Stage === 'Student').length);
+    const offerCounts = dates.map(d => data.filter(r => r.StartDate === d && r.Stage === 'Offer').length);
+    chartData = {
+      labels: dates,
+      datasets: [
+        { label: 'Students', data: studentCounts, fill: false, borderColor: '#5e4ae3' },
+        { label: 'Offers', data: offerCounts, fill: false, borderColor: '#f06595' }
+      ]
+    };
+  } else if (reportName === 'enrolled-offer') {
+    chartType = 'bar';
+    const totalStudents = data.filter(r => r.Stage === 'Student').length;
+    const totalOffers = data.filter(r => r.Stage === 'Offer').length;
+    chartData = {
+      labels: ['Students', 'Offers'],
+      datasets: [{ label: 'Count', data: [totalStudents, totalOffers], backgroundColor: ['#5e4ae3', '#74c69d'] }]
+    };
+  } else if (reportName === 'visa-breakdown') {
+    chartType = 'doughnut';
+    const visaCounts = {};
+    data.forEach(r => {
+      const v = r['Visa Status'] || 'Unknown';
+      visaCounts[v] = (visaCounts[v] || 0) + 1;
+    });
+    chartData = {
+      labels: Object.keys(visaCounts),
+      datasets: [{
+        data: Object.values(visaCounts),
+        backgroundColor: ['#5e4ae3', '#f06595', '#74c69d', '#ffd43b', '#adb5bd'],
+        borderWidth: 2,
+        borderColor: '#fff'
+      }]
+    };
+    options.plugins = { legend: { position: 'bottom' } };
+  } else if (reportName === 'offer-expiry') {
+    chartType = 'line';
+    const expiryDates = [...new Set(data.map(r => r['Offer Expiry Date']).filter(Boolean))]
+      .sort((a, b) => new Date(a) - new Date(b));
+    const expiryCounts = expiryDates.map(d => data.filter(r => r['Offer Expiry Date'] === d).length);
+    chartData = {
+      labels: expiryDates,
+      datasets: [{ label: 'Expiry Count', data: expiryCounts, fill: false, borderColor: '#5e4ae3' }]
+    };
+  }
+
+  new Chart(ctx, {
+    type: chartType,
+    data: chartData,
+    options
+  });
+}
+
+fetch('/api/data')
+  .then(r => r.json())
+  .then(renderReport)
+  .catch(err => console.error('Data load error:', err));

--- a/frontend/static/Js/managerial-landing-dashboard.js
+++ b/frontend/static/Js/managerial-landing-dashboard.js
@@ -42,12 +42,17 @@ document.addEventListener("DOMContentLoaded", function () {
       visaCounts[v] = (visaCounts[v] || 0) + 1;
     });
     chartVisa = new Chart(document.getElementById("chart-visa-breakdown"), {
-      type: "pie",
+      type: "doughnut",
       data: {
         labels: Object.keys(visaCounts),
-        datasets: [{ data: Object.values(visaCounts) }]
+        datasets: [{
+          data: Object.values(visaCounts),
+          backgroundColor: ['#5e4ae3', '#f06595', '#74c69d', '#ffd43b', '#adb5bd'],
+          borderColor: '#fff',
+          borderWidth: 2
+        }]
       },
-      options: { responsive: true }
+      options: { responsive: true, plugins: { legend: { position: 'bottom' } } }
     });
 
     const expiryDates = [...new Set(data.map(r => r["Offer Expiry Date"]).filter(Boolean))]

--- a/frontend/templates/create_dashboard.html
+++ b/frontend/templates/create_dashboard.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block title %}Create Dashboard{% endblock %}
+{% block content %}
+<div class="container py-5 text-center">
+  <h1 class="mb-4">Create Dashboard</h1>
+  <p class="lead">This section will allow managers to build new dashboards from approved data.</p>
+  <p>Feature under active development.</p>
+  <a href="{{ url_for('dashboard.dashboard') }}" class="btn btn-primary mt-3">Back</a>
+</div>
+{% endblock %}

--- a/frontend/templates/download_data.html
+++ b/frontend/templates/download_data.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block title %}Download Data{% endblock %}
+{% block content %}
+<div class="container py-5 text-center">
+  <h1 class="mb-4">Download Data</h1>
+  <p class="lead">Export the latest dashboard information.</p>
+  <a class="btn btn-primary me-2" href="{{ url_for('dashboard.export_data', fmt='pdf') }}">Export PDF</a>
+  <a class="btn btn-secondary" href="{{ url_for('dashboard.export_data', fmt='excel') }}">Export Excel</a>
+  <div class="mt-4">
+    <a href="{{ url_for('dashboard.dashboard') }}" class="btn btn-light">Back</a>
+  </div>
+</div>
+{% endblock %}

--- a/frontend/templates/manager-report.html
+++ b/frontend/templates/manager-report.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}{{ title }} Report{% endblock %}
+{% block extra_head %}
+  <link rel="stylesheet" href="{{ url_for('static', filename='Css/style.css') }}" />
+{% endblock %}
+{% block content %}
+<div class="container py-5">
+  <h1 class="mb-4 text-center">{{ title }} Report</h1>
+  <canvas id="reportChart" height="400"></canvas>
+  <div class="text-center mt-4">
+    <a href="{{ url_for('dashboard.dashboard') }}" class="btn btn-primary">Back to Dashboard</a>
+  </div>
+</div>
+{% endblock %}
+{% block extra_js %}
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script>const reportName = "{{ report_name }}";</script>
+  <script src="{{ url_for('static', filename='Js/manager-report.js') }}" defer></script>
+{% endblock %}

--- a/frontend/templates/managerial-landing-dashboard.html
+++ b/frontend/templates/managerial-landing-dashboard.html
@@ -9,14 +9,13 @@
   <div class="row min-vh-100">
     <nav class="col-md-2 bg-light sidebar p-3">
       <div class="text-center mb-4">
-        <img src="{{ url_for('static', filename='Assets/logo.png') }}" class="img-fluid" alt="Analytics Institute Logo" />
         <h4 class="mt-2">Analytics Institute</h4>
       </div>
       <ul class="nav flex-column">
         <li class="nav-item"><a class="nav-link active" href="{{ url_for('dashboard.dashboard') }}">Dashboard</a></li>
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('main.coming_soon', page='create-dashboard') }}">Create Dashboard</a></li>
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('main.coming_soon', page='download-data') }}">Download Data</a></li>
-        <li class="nav-item"><a class="nav-link" href="{{ url_for('main.coming_soon', page='settings') }}">Settings</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('dashboard.create_dashboard') }}">Create Dashboard</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('dashboard.download_data_page') }}">Download Data</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url_for('dashboard.settings_page') }}">Settings</a></li>
       </ul>
     </nav>
 
@@ -34,7 +33,7 @@
           <div class="card h-100 chart-card">
             <div class="card-header bg-white d-flex justify-content-between align-items-center">
               <h5 class="card-title mb-0">Current Student vs Enrolled</h5>
-              <a class="btn btn-sm btn-outline-primary" href="{{ url_for('main.coming_soon', page='current-student') }}">View Report</a>
+              <a class="btn btn-sm btn-outline-primary" href="{{ url_for('dashboard.report_detail', report_name='current-student') }}">View Report</a>
             </div>
             <div class="card-body">
               <canvas id="chart-current-enrolled"></canvas>
@@ -45,7 +44,7 @@
           <div class="card h-100 chart-card">
             <div class="card-header bg-white d-flex justify-content-between align-items-center">
               <h5 class="card-title mb-0">Enrolled Vs Offer</h5>
-              <a class="btn btn-sm btn-outline-primary" href="{{ url_for('main.coming_soon', page='enrolled-offer') }}">View Report</a>
+              <a class="btn btn-sm btn-outline-primary" href="{{ url_for('dashboard.report_detail', report_name='enrolled-offer') }}">View Report</a>
             </div>
             <div class="card-body">
               <canvas id="chart-enrolled-offer"></canvas>
@@ -56,7 +55,7 @@
           <div class="card h-100 chart-card">
             <div class="card-header bg-white d-flex justify-content-between align-items-center">
               <h5 class="card-title mb-0">Visa Breakdown</h5>
-              <a class="btn btn-sm btn-outline-primary" href="{{ url_for('main.coming_soon', page='visa-breakdown') }}">View Report</a>
+              <a class="btn btn-sm btn-outline-primary" href="{{ url_for('dashboard.report_detail', report_name='visa-breakdown') }}">View Report</a>
             </div>
             <div class="card-body">
               <canvas id="chart-visa-breakdown"></canvas>
@@ -67,7 +66,7 @@
           <div class="card h-100 chart-card">
             <div class="card-header bg-white d-flex justify-content-between align-items-center">
               <h5 class="card-title mb-0">Offer Expiry Surge</h5>
-              <a class="btn btn-sm btn-outline-primary" href="{{ url_for('main.coming_soon', page='offer-expiry') }}">View Report</a>
+              <a class="btn btn-sm btn-outline-primary" href="{{ url_for('dashboard.report_detail', report_name='offer-expiry') }}">View Report</a>
             </div>
             <div class="card-body">
               <canvas id="chart-offer-expiry-surge"></canvas>

--- a/frontend/templates/settings.html
+++ b/frontend/templates/settings.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block title %}Settings{% endblock %}
+{% block content %}
+<div class="container py-5 text-center">
+  <h1 class="mb-4">Settings</h1>
+  <p class="lead">Manage your dashboard preferences here.</p>
+  <p>Additional configuration options will appear soon.</p>
+  <a href="{{ url_for('dashboard.dashboard') }}" class="btn btn-primary mt-3">Back</a>
+</div>
+{% endblock %}

--- a/server/blueprints/dashboard.py
+++ b/server/blueprints/dashboard.py
@@ -142,3 +142,38 @@ def api_published():
     records = ImportedData.query.filter_by(approved=True).all()
     payload = [r.data for r in records]
     return jsonify(payload)
+
+
+# ----- Manager specific pages -----
+
+@dashboard_bp.route('/report/<report_name>')
+@login_required
+def report_detail(report_name: str):
+    if current_user.role.name.lower() != 'manager':
+        return redirect(url_for('auth.login'))
+    title = report_name.replace('-', ' ').title()
+    return render_template('manager-report.html', report_name=report_name, title=title)
+
+
+@dashboard_bp.route('/manager/create-dashboard')
+@login_required
+def create_dashboard():
+    if current_user.role.name.lower() != 'manager':
+        return redirect(url_for('auth.login'))
+    return render_template('create_dashboard.html')
+
+
+@dashboard_bp.route('/manager/download-data')
+@login_required
+def download_data_page():
+    if current_user.role.name.lower() != 'manager':
+        return redirect(url_for('auth.login'))
+    return render_template('download_data.html')
+
+
+@dashboard_bp.route('/manager/settings')
+@login_required
+def settings_page():
+    if current_user.role.name.lower() != 'manager':
+        return redirect(url_for('auth.login'))
+    return render_template('settings.html')


### PR DESCRIPTION
## Summary
- add routes for detailed manager reports
- create new pages for dashboard actions
- update manager dashboard links and remove duplicate logo
- improve visa breakdown chart styling
- add JS for new report pages

## Testing
- `python3 -m compileall server`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e98af6c28832880cb38a3c8d5d337