### PR TITLE
Fix visa breakdown chart display

### DIFF
--- a/frontend/static/Js/manager-report.js
+++ b/frontend/static/Js/manager-report.js
@@ -1,3 +1,7 @@
+if (typeof Chart !== 'undefined' && typeof ChartDataLabels !== 'undefined') {
+  Chart.register(ChartDataLabels);
+}
+
 // Render report specific charts
 function renderReport(data) {
   let ctx = document.getElementById('reportChart');
@@ -50,10 +54,20 @@ function renderReport(data) {
         data: Object.values(visaCounts),
         backgroundColor: ['#5e4ae3', '#f06595', '#74c69d', '#ffd43b', '#adb5bd'],
         borderWidth: 2,
-        borderColor: '#fff'
+        borderColor: '#fff',
+        spacing: 2
       }]
     };
-    options.plugins = { legend: { position: 'bottom' } };
+    options.plugins = {
+      legend: { position: 'bottom', labels: { padding: 20 } },
+      datalabels: {
+        color: '#000',
+        formatter: (value, ctx) => {
+          const sum = ctx.dataset.data.reduce((a, b) => a + b, 0);
+          return sum ? ((value / sum) * 100).toFixed(1) + '%';
+        }
+      }
+    };
   } else if (reportName === 'offer-expiry') {
     chartType = 'line';
     const expiryDates = [...new Set(data.map(r => r['Offer Expiry Date']).filter(Boolean))]

--- a/frontend/templates/manager-report.html
+++ b/frontend/templates/manager-report.html
@@ -14,6 +14,7 @@
 {% endblock %}
 {% block extra_js %}
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
   <script>const reportName = "{{ report_name }}";</script>
   <script src="{{ url_for('static', filename='Js/manager-report.js') }}" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- register the Chart.js datalabels plugin for manager reports
- show percentage labels and better spacing for visa breakdown pie chart
- include datalabels script in the manager report page
